### PR TITLE
Fix book duplication

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,9 +15,8 @@ local function on_place(itemstack, placer, pointed_thing)
 		return itemstack
 	end
 
-	local def = minetest.registered_nodes[minetest.get_node(pointed_thing.under).name]
-	local pointed_on_rightclick = def.on_rightclick
-	if pointed_on_rightclick and (def.legacy_wallmounted or def.wallmounted) then
+	local pointed_on_rightclick = minetest.registered_nodes[minetest.get_node(pointed_thing.under).name].on_rightclick
+	if pointed_on_rightclick and not placer:get_player_control().sneak then
 		return pointed_on_rightclick(pointed_thing.under, minetest.get_node(pointed_thing.under), placer, itemstack)
 	end
 	local data = itemstack:get_meta()
@@ -26,7 +25,7 @@ local function on_place(itemstack, placer, pointed_thing)
 	if data and data_owner then
 		copymeta(itemstack:get_meta(), stack:get_meta() )
 	end
-	local _, placed = minetest.item_place(stack, placer, pointed_thing)
+	local _, placed = minetest.item_place_node(stack, placer, pointed_thing, nil)
 	if placed then
 		itemstack:take_item()
 	end

--- a/init.lua
+++ b/init.lua
@@ -15,13 +15,17 @@ local function on_place(itemstack, placer, pointed_thing)
 		return itemstack
 	end
 
+	local def = minetest.registered_nodes[minetest.get_node(pointed_thing.under).name]
+	local pointed_on_rightclick = def.on_rightclick
+	if pointed_on_rightclick and (def.legacy_wallmounted or def.wallmounted) then
+		return pointed_on_rightclick(pointed_thing.under, minetest.get_node(pointed_thing.under), placer, itemstack)
+	end
 	local data = itemstack:get_meta()
 	local data_owner = data:get_string("owner")
 	local stack = ItemStack({name = "default:book_closed"})
 	if data and data_owner then
 		copymeta(itemstack:get_meta(), stack:get_meta() )
 	end
-
 	local _, placed = minetest.item_place(stack, placer, pointed_thing)
 	if placed then
 		itemstack:take_item()

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,2 @@
 name = books
+depends = default


### PR DESCRIPTION
This happened when placing a book on an `itemframes:itemframe` from `homedecor`.
Now books are placed correctly in itemframes and doesn't duplicate anymore.