### PR TITLE
Add support for MT5 builtin client-side translation

### DIFF
--- a/locale/books.fr.tr
+++ b/locale/books.fr.tr
@@ -1,0 +1,15 @@
+# textdomain: books
+
+
+### init.lua ###
+
+@1@n@nby @2=@1@n@npar @2
+Admin Pencil=Crayon d’administrateur
+Allow player to edit books with the Admin Pencil=Autorise le joueur à écrire dans les livres avec le crayon d’administrateur
+Book Closed=Livre fermé
+Book Open=Livre ouvert
+Contents:=Contenu :
+Owner:=Propriétaire :
+Page @1 of @2=Page @1 sur @2
+Save=Sauvegarder
+Title:=Titre :

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,0 +1,15 @@
+# textdomain: books
+
+
+### init.lua ###
+
+@1@n@nby @2=
+Admin Pencil=
+Allow player to edit books with the Admin Pencil=
+Book Closed=
+Book Open=
+Contents:=
+Owner:=
+Page @1 of @2=
+Save=
+Title:=

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,2 @@
 name = books
+min_minetest_version = 5.0.0

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,1 @@
+books.editor (Enable Admin Pencil) bool false


### PR DESCRIPTION
- Add french translation
- Use groups when available
- Settings are read from minetest.conf using up-to-date API
- Add `min_minetest_version` to 5.0.0 in `mod.conf`